### PR TITLE
ページネーション処理を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ atlas migrate apply \
 func (t *TimelineController) Index(c *gin.Context)
 ```
 
-#### swag fmtコマンドを実行してファイルを自動整形
+#### ファイルを自動整形
+'''
+swag fmt
+'''
 
-#### swag initコマンドを実行してswaggerファイルを自動生成
+#### swaggerファイルを自動生成
+```
+swag init
+```

--- a/app/app_types/page.go
+++ b/app/app_types/page.go
@@ -1,16 +1,16 @@
 package app_types
 
 type Page struct {
-	pageSize      int
-	prevPageToken string
-	nextPageToken string
+	pageSize   int
+	prevPageId string
+	nextPageId string
 }
 
-func NewPage(pageSize int, prevPageToken string, nextPageToken string) *Page {
+func NewPage(pageSize int, prevPageId string, nextPageId string) *Page {
 	return &Page{
-		pageSize:      pageSize,
-		prevPageToken: prevPageToken,
-		nextPageToken: nextPageToken,
+		pageSize:   pageSize,
+		prevPageId: prevPageId,
+		nextPageId: nextPageId,
 	}
 }
 
@@ -18,10 +18,22 @@ func (p *Page) PageSize() int {
 	return p.pageSize
 }
 
-func (p *Page) PrevPageToken() string {
-	return p.prevPageToken
+func (p *Page) PrevPageId() string {
+	return p.prevPageId
 }
 
-func (p *Page) NextPageToken() string {
-	return p.nextPageToken
+func (p *Page) NextPageId() string {
+	return p.nextPageId
+}
+
+func (p *Page) SetPageSize(value int) {
+	p.pageSize = value
+}
+
+func (p *Page) SetPrevPageId(value string) {
+	p.prevPageId = value
+}
+
+func (p *Page) SetNextPageId(value string) {
+	p.nextPageId = value
 }

--- a/app/app_types/page_response.go
+++ b/app/app_types/page_response.go
@@ -1,15 +1,15 @@
 package app_types
 
 type PageResponse struct {
-	PageSize      int    `json:"page_size"`
-	PrevPageToken string `json:"prev_page_token"`
-	NextPageToken string `json:"next_page_token"`
+	PageSize   int    `json:"page_size"`
+	PrevPageId string `json:"prev_page_id"`
+	NextPageId string `json:"next_page_id"`
 }
 
 func NewPageResponse(page *Page) *PageResponse {
 	return &PageResponse{
-		PageSize:      page.PageSize(),
-		PrevPageToken: page.PrevPageToken(),
-		NextPageToken: page.NextPageToken(),
+		PageSize:   page.PageSize(),
+		PrevPageId: page.PrevPageId(),
+		NextPageId: page.NextPageId(),
 	}
 }

--- a/app/infrastructures/query_services/timeline_query_service_impl.go
+++ b/app/infrastructures/query_services/timeline_query_service_impl.go
@@ -43,9 +43,9 @@ func (t *TimelineQueryServiceImpl) Fetch(page *app_types.Page) ([]*usecases.Time
 		nextPage.SetNextPageId(strconv.Itoa(timelines[len(timelines)-1].ID))
 		timelines = timelines[:len(timelines)-1]
 		nextPage.SetPageSize(len(timelines))
-	} else {
-		nextPage.SetPageSize(len(timelines))
 	}
+
+	nextPage.SetPageSize(len(timelines))
 
 	var timelineList []*usecases.TimelineDto
 	for _, result := range timelines {

--- a/app/infrastructures/query_services/timeline_query_service_impl.go
+++ b/app/infrastructures/query_services/timeline_query_service_impl.go
@@ -2,10 +2,13 @@ package query_services
 
 import (
 	"context"
+	"strconv"
 	"study-pal-backend/app/app_types"
 	"study-pal-backend/app/usecases"
 	"study-pal-backend/app/utils/application_errors"
+	"study-pal-backend/app/utils/converts"
 	"study-pal-backend/ent"
+	"study-pal-backend/ent/article"
 )
 
 type TimelineQueryServiceImpl struct {
@@ -21,14 +24,31 @@ func NewTimelineQueryServiceImpl(ctx context.Context, client *ent.Client) usecas
 }
 
 func (t *TimelineQueryServiceImpl) Fetch(page *app_types.Page) ([]*usecases.TimelineDto, *app_types.Page, application_errors.ApplicationError) {
-	results, err := t.client.Article.Query().WithPost().All(t.ctx)
+	limit := page.PageSize() + 1
+
+	query := t.client.Article.Query().WithPost().Limit(limit)
+
+	if converts.StringToInt(page.NextPageId(), 0) > 0 {
+		query = t.client.Article.Query().WithPost().Where(article.IDGTE(converts.StringToInt(page.NextPageId(), 0))).Limit(limit)
+	}
+
+	timelines, err := query.All(t.ctx)
 
 	if err != nil {
 		return nil, nil, application_errors.NewDatabaseConnectionApplicationError(err)
 	}
 
+	nextPage := app_types.NewPage(0, "", "")
+	if len(timelines) > page.PageSize() {
+		nextPage.SetNextPageId(strconv.Itoa(timelines[len(timelines)-1].ID))
+		timelines = timelines[:len(timelines)-1]
+		nextPage.SetPageSize(len(timelines))
+	} else {
+		nextPage.SetPageSize(len(timelines))
+	}
+
 	var timelineList []*usecases.TimelineDto
-	for _, result := range results {
+	for _, result := range timelines {
 		timelineList = append(timelineList, usecases.NewTimelineDto(
 			result.ID,
 			result.Description,
@@ -37,5 +57,5 @@ func (t *TimelineQueryServiceImpl) Fetch(page *app_types.Page) ([]*usecases.Time
 			result.Edges.Post.NickName,
 		))
 	}
-	return timelineList, app_types.NewPage(2, "a", "b"), nil
+	return timelineList, nextPage, nil
 }

--- a/app/utils/converts/type_convert.go
+++ b/app/utils/converts/type_convert.go
@@ -1,0 +1,12 @@
+package converts
+
+import "strconv"
+
+func StringToInt(value string, defaultValue int) int {
+	result, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue
+	}
+
+	return result
+}

--- a/app/utils/converts/type_convert_test.go
+++ b/app/utils/converts/type_convert_test.go
@@ -1,0 +1,19 @@
+package converts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringToInt_正常な値の時に変換されているか(t *testing.T) {
+	value := StringToInt("1", 0)
+
+	assert.Equal(t, 1, value)
+}
+
+func TestStringToInt_正常じゃない値の時にデフォルト値になるか(t *testing.T) {
+	value := StringToInt("test", 0)
+
+	assert.Equal(t, 0, value)
+}

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ import (
 
 //	@securityDefinitions.basic	JWTAuth
 
-//	@externalDocs.description	OpenAPI
-//	@externalDocs.url			https://swagger.io/resources/open-api/
+// @externalDocs.description	OpenAPI
+// @externalDocs.url			https://swagger.io/resources/open-api/
 func main() {
 	err := godotenv.Load(".env")
 	if err != nil {
@@ -56,6 +56,7 @@ func main() {
 	r := gin.New()
 	r.Use(gin.Logger())
 	r.Use(gin.Recovery())
+
 	v1 := r.Group("/api/v1")
 	{
 		v1.GET("/timelines", timelineController.Index)


### PR DESCRIPTION
Close #6
共通化として下記のような関数を定義して共通化を図ろうとしたがこれだとコンパイルエラーになりうるので無理だった。
func Pagenation[T any](queryFunc func() ([]*T, error), page Page) ([]*T, *Page, application_errors.ApplicationError) {
	result, _ := queryFunc()
	nextPage := NewPage(0, "", "")
	nextPage.SetNextPageId(strconv.Itoa(result[len(result)-1].ID))
}